### PR TITLE
Thunkify every request method

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,34 +7,69 @@ var __slice = Array.prototype.slice;
  * @param  {Function} fn
  * @return {Function}
  */
-var thunkifyRequest = function (fn) {
+var thunkifyRequestMethod = function (fn) {
   return function () {
     var args    = __slice.call(arguments);
     var context = this;
 
     return function (done) {
-      // Push the callback manually to avoid additional arguments from co.
-      args.push(function (err, res) {
+      // Concatinate the callback manually to avoid array arguments from co.
+      return fn.apply(context, args.concat(function (err, res) {
         done(err, res);
-      });
-
-      return fn.apply(context, args);
+      }));
     };
   };
 };
 
 /**
- * Export the thunkified base request function.
+ * Thunkify a request function.
+ *
+ * @param  {Function} request
+ * @return {Function}
+ */
+var thunkifyRequest = function (request) {
+  var fn = thunkifyRequestMethod(request);
+
+  // Regular request methods that don't need be thunkified.
+  fn.jar    = request.jar;
+  fn.cookie = request.cookie;
+
+  // Attach all request methods.
+  ['get', 'patch', 'post', 'put', 'head', 'del'].forEach(function (method) {
+    fn[method] = thunkifyRequestMethod(request[method]);
+  });
+
+  return fn;
+};
+
+/**
+ * Export a thunkified request function.
  *
  * @type {Function}
  */
 exports = module.exports = thunkifyRequest(request);
 
-// Regular request methods that don't need be thunkified.
-exports.jar    = request.jar;
-exports.cookie = request.cookie;
+/**
+ * Export the Request instance.
+ *
+ * @type {Function}
+ */
+exports.Request = request.Request;
 
-// Attach all the regular request methods.
-['get', 'patch', 'post', 'put', 'head', 'del'].forEach(function (method) {
-  exports[method] = thunkifyRequest(request[method]);
-});
+/**
+ * Export the defaults method and return a thunkified request instance.
+ *
+ * @return {Function}
+ */
+exports.defaults = function () {
+  return thunkifyRequest(request.defaults.apply(request, arguments));
+};
+
+/**
+ * Export the forever agent method and return a thunkified request instance.
+ *
+ * @return {Function}
+ */
+exports.forever = function () {
+  return thunkifyRequest(request.forever.apply(request, arguments));
+};


### PR DESCRIPTION
Adds support for all request methods attached to the base function. Also allows a combination of url string and object options like the normal request function.
