### PR TITLE
Allow nested defaults and forever calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,16 @@ let promisifyRequest = function (request) {
     fn.jar    = request.jar;
     fn.cookie = request.cookie;
 
+    // Export the defaults method and return a promisified request instance.
+    fn.defaults = function () {
+        return promisifyRequest(request.defaults.apply(request, arguments));
+    };
+
+    // Export the forever agent method and return a promisified request instance.
+    fn.forever = function () {
+        return promisifyRequest(request.forever.apply(request, arguments));
+    };
+
     // Attach all request methods.
     ["get", "patch", "post", "put", "head", "del"].forEach(function (method) {
         fn[method] = promisifyRequestMethod.call(request, request[method]);
@@ -63,21 +73,3 @@ exports = module.exports = promisifyRequest(request);
  * @type {Function}
  */
 exports.Request = request.Request;
-
-/**
- * Export the defaults method and return a promisified request instance.
- *
- * @return {Function}
- */
-exports.defaults = function () {
-    return promisifyRequest(request.defaults.apply(request, arguments));
-};
-
-/**
- * Export the forever agent method and return a promisified request instance.
- *
- * @return {Function}
- */
-exports.forever = function () {
-    return promisifyRequest(request.forever.apply(request, arguments));
-};


### PR DESCRIPTION
The request library states

> You can call .defaults() on the wrapper that is returned from request.defaults to add/override defaults that were previously defaulted.

This pull request restores that functionality for co-request.

Example:

``` javascript
var baseReq = request.defaults({headers:{DNT: 1}});
var jsonReq = baseReq.defaults({json: true});
jsonReq('https://someserver/activity.json'); // Will have json set to true and DNT header set
```
